### PR TITLE
Handle object-dtype ndarrays separately

### DIFF
--- a/numpyson.py
+++ b/numpyson.py
@@ -76,9 +76,9 @@ class PandasTimeSeriesHandler(BaseHandler):
 
     def flatten(self, obj, data):
         values = self.nflatten(obj.values)
-        index = self.nflatten(obj.index.values)
+        index = self.nflatten(obj.index)
         args = [values, index]
-        data['__reduce__'] = (self.nflatten(pd.TimeSeries), args)
+        data['__reduce__'] = (self.nflatten(pd.Series), args)
         return data
 
     def restore(self, obj):
@@ -141,7 +141,7 @@ class PandasDataFrameHandler(BaseHandler):
         pickler = self.context
         flatten = pickler.flatten
         values = [flatten(obj[col].values) for col in obj.columns]
-        index = flatten(obj.index.values)
+        index = flatten(obj.index)
         columns = flatten(obj.columns.values)
         args = [values, index, columns]
         data['__reduce__'] = (flatten(pd.DataFrame), args)
@@ -167,7 +167,7 @@ def register_handlers():
     PandasInt64IndexHandler.handles(pd.Int64Index)
     PandasFloat64IndexHandler.handles(pd.Float64Index)
 
-    PandasTimeSeriesHandler.handles(pd.TimeSeries)
+    PandasTimeSeriesHandler.handles(pd.Series)
 
     PandasDataFrameHandler.handles(pd.DataFrame)
 


### PR DESCRIPTION
Hi,

Unpickling pickled ndarrays with dtype of object seems to work as long as the interpreter has not been restarted between pickling and unpickling. For example, after flattening

``` python
import datetime
import numpy as np
dates_list = [
    datetime.datetime(2015, 3, 19, 16, 11, 20),
    datetime.datetime(2015, 3, 31, 16, 11, 21),
    datetime.datetime(2015, 5, 18, 16, 11, 23),
    datetime.datetime(2015, 1, 6, 16, 11, 26),
    datetime.datetime(2015, 1, 30, 16, 11, 26),
    datetime.datetime(2015, 6, 11, 16, 11, 25),
    datetime.datetime(2014, 12, 1, 16, 11, 28),
    datetime.datetime(2015, 2, 23, 16, 11, 25),
    datetime.datetime(2015, 4, 24, 16, 11, 21),
    datetime.datetime(2015, 1, 18, 16, 11, 26),
    datetime.datetime(2015, 3, 7, 16, 11, 26),
    datetime.datetime(2014, 12, 13, 16, 11, 27),
    datetime.datetime(2014, 11, 7, 16, 11, 28),
    datetime.datetime(2015, 4, 12, 16, 11, 21)
]
dates = np.asarray(dates_list)
```

which results in

``` json
{
    "__reduce__": [
        {
            "py/type": "numpy.ndarray"
        },
        [
            {
                "py/tuple": [
                    14
                ]
            },
            "object",
            "cHa9BAAAAAA4d70EAAAAACB7vQQAAAAASHu9BAAAAABwe70EAAAAAJh7vQQAAAAAwHu9BAAAAADoe70EAAAAABB8vQQAAAAAYHy9BAAAAAA4fL0EAAAAAIh8vQQAAAAAsHy9BAAAAADYfL0EAAAAAA==",
            "F"
        ]
    ],
    "py/object": "numpy.ndarray"
}
```

the flattened object crashes the Python interpreter when doing a restore() when using it in a new interpreter session.

I suggest a fix to this by converting the data content of an object-dtype ndarray to a list and calling flatten() on it separately.
